### PR TITLE
Update cart.model.ts

### DIFF
--- a/Chapter 09/SportsStore/ClientApp/src/app/models/cart.model.ts
+++ b/Chapter 09/SportsStore/ClientApp/src/app/models/cart.model.ts
@@ -11,7 +11,20 @@ export class Cart {
     constructor(private repo: Repository) {
         repo.getSessionData<ProductSelection[]>("cart").subscribe(cartData => {
             if (cartData != null) {
-                cartData.forEach(item => this.selections.push(item));
+                //cartData.forEach(item => this.selections.push(item));
+                cartData.forEach(item =>
+                {
+                    //	Transform the data structure into a full instance with methods.
+                    let ps = new ProductSelection(this,
+                        item.productId,
+                        item.name,
+                        item.price,
+                        item.quantity);
+                    //	Push the instance into the collection.
+                    //	Two-way binding will now work because properties and methods exist.
+                    //	Pushing the bare structure fails to provide methods and properties.
+                    this.selections.push(ps);
+                });
                 this.update(false);
             }
         });


### PR DESCRIPTION
I love the book.  

In chapter 9, there is a silent and deadly bug created by adding Session to persist ProductSelections.  Afterwards, when you edit an item's quantity, your Angular program dies when trying to access the quantity property via 2-way binding.  Yet it worked before Session was added!  How could adding Session, cause failure?  After verifying the Session API, the problem had to be within ClientApp.  Debugging by stepping through the code, I found that the instances retrieved from HTTP GET were naked, having undefined (added while tracing) methods and properties.  It was the oui-la moment.